### PR TITLE
change import not to be relative

### DIFF
--- a/pyutils/_env_manager.py
+++ b/pyutils/_env_manager.py
@@ -3,7 +3,7 @@
 
 import os
 import subprocess
-from .pylogger import Logger
+from pylogger import Logger
 
 ENV_IS_SETUP = False
 

--- a/pyutils/pyimport.py
+++ b/pyutils/pyimport.py
@@ -1,7 +1,7 @@
 import uproot
 import awkward as ak
-from .pyread import Reader
-from .pylogger import Logger
+from pyread import Reader
+from pylogger import Logger
 
 class Importer:
     """Utility class for importing branches from ROOT TTree files

--- a/pyutils/pyplot.py
+++ b/pyutils/pyplot.py
@@ -8,7 +8,7 @@ from scipy import stats
 from matplotlib.ticker import ScalarFormatter
 import matplotlib.colors as colors
 
-from .pylogger import Logger
+from pylogger import Logger
 
 class Plot:
     """ 

--- a/pyutils/pyprint.py
+++ b/pyutils/pyprint.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 import awkward as ak
-from .pylogger import Logger
+from pylogger import Logger
 
 class Print:
     """

--- a/pyutils/pyprocess.py
+++ b/pyutils/pyprocess.py
@@ -6,9 +6,9 @@ import awkward as ak
 import inspect
 import tqdm
 import gc
-from . import _env_manager # Environment manager
-from .pyimport import Importer # For importing branches
-from .pylogger import Logger # Messaging/logging
+from _env_manager import * # Environment manager
+from pyimport import Importer # For importing branches
+from pylogger import Logger # Messaging/logging
 
 # TODO: implement failed file handling, accumalation across threads and dask.awkward
 

--- a/pyutils/pyread.py
+++ b/pyutils/pyread.py
@@ -2,8 +2,8 @@
 import uproot
 import os
 import subprocess
-from . import _env_manager # Environment manager
-from .pylogger import Logger # Messaging/logging
+from _env_manager import * # Environment manager
+from pylogger import Logger # Messaging/logging
 
 class Reader:
     """Unified interface for accessing files, either locally or remotely"""

--- a/pyutils/pyselect.py
+++ b/pyutils/pyselect.py
@@ -2,7 +2,7 @@
 import uproot
 import awkward as ak
 import numpy as np
-from .pylogger import Logger
+from pylogger import Logger
     
 class Select:
     """

--- a/pyutils/pyvector.py
+++ b/pyutils/pyvector.py
@@ -4,7 +4,7 @@ import awkward as ak
 import math
 import numpy as np
 import vector
-from .pylogger import Logger
+from pylogger import Logger
 
 class Vector:
 


### PR DESCRIPTION
I cannot use pyutils whithin another folder because the python imports are relative. There might be a better solution than this, but this quick fix at least works for me.