### PR TITLE
Fallback for incorrect file location

### DIFF
--- a/pyutils/_env_manager.py
+++ b/pyutils/_env_manager.py
@@ -38,7 +38,7 @@ def setup_environment():
                 return False
                 
             # Step 2: Setup mu2e environment and get all environmentals
-            setup_cmd = "source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh; muse setup ops; env"
+            setup_cmd = "source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh; muse setup ops; setup dhtools; env"
             
             result = subprocess.check_output(
                 setup_cmd, 

--- a/pyutils/pyimport.py
+++ b/pyutils/pyimport.py
@@ -20,6 +20,7 @@ class Importer:
             location: Remote files only. File location: tape (default), disk, scratch, nersc 
             schema: Remote files only. Schema used when writing the URL: root (default), http, path, dcap, samFile
             verbosity: Print detail level (0: minimal, 1: medium, 2: maximum) 
+            
         """
         self.file_name = file_name
         self.branches = branches
@@ -39,7 +40,7 @@ class Importer:
             use_remote=self.use_remote,
             location=self.location,
             schema=self.schema,
-            verbosity=self.verbosity 
+            verbosity=self.verbosity    
         )
         
     def import_branches(self):
@@ -48,13 +49,9 @@ class Importer:
         Returns:
             Awkward array with imported data
         """
-
-        # Get uproot object
-        # Init file variable before try block
-        # Reader has it's own try blocks
-        file = self.reader.read_file(self.file_name) 
-        
         try:
+            # Open file 
+            file = self.reader.read_file(self.file_name) 
             # Access the tree
             components = self.tree_path.split('/')
             current = file
@@ -68,11 +65,6 @@ class Importer:
                     return None
             # Set tree
             tree = current 
-            
-            # # Print tree info 
-            # self.logger.log("Accessing branches in tree:", "max")
-            # if self.verbosity > 1:
-            #     tree.show(self.branches, interpretation_width=100)
                 
             # Result container
             result = {}
@@ -118,7 +110,7 @@ class Importer:
     
         except Exception as e:
             self.logger.log(f"Exception getting branches in file {self.file_name}: {e}", "error")
-            return None
+            raise # Propagate exception
 
         finally:
             # Ensure the file is closed


### PR DESCRIPTION
The `location` flag for remote files comes from the `mdh` command 

```
mdh print-url <file_name> -l <location> 
```

the default is `tape`, where the usual alternatives are `disk` and `scratch`. 

Previously, if the location was set incorrectly, the process would simply fail and it may not be immediately obvious as to what happened.

I implemented a fallback procedure in `pyread` to check the file path using `samweb locate-file`. It corrects the location, if it can, and prints some warnings to inform the user as to what happened. I also included a preprocessing test in `pyprocess`, to the read the first file in the queue and print the same warnings if the location is wrong (worker processes are silenced during real processing, so the warnings from `pyread` would be missed). 

See examples:

```python
from pyutils.pyprocess import Processor

processor = Processor(
    use_remote=True,
    verbosity=1,
    location="scratch" # INCORRECT 
)
```

```
[pyutils] ⭐️ Setting up...
[pyutils] ✅ Ready
[pyprocess] ⭐️ Initialised Processor:
	path = 'EventNtuple/ntuple'
	use_remote = True
	location = scratch
	schema = root
	verbosity=1
```

```python
# SINGLE FILE
file_name = "nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root"

processor.process_data(
    file_name=file_name,
    branches=["event"]
)
```

```
[pyread] ⭐️ Opening remote file: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyread] ⚠️ Exception while opening root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root: File did not open properly: [FATAL] TLS error: Unable to validate 131.225.69.80; hostname not in SAN extension.
[pyread] ⭐️ Fallback: checking file location='scratch'
[pyread] ✅ Files found on 'tape', retrying
[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyimport] ✅ Imported branches
[pyprocess] ✅ Completed process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
```

```python
# MULTIPROCESSING
file_list_path = "/exp/mu2e/data/users/sgrant/pyutils-test/TestFileLists/remote_file_list.txt"

processor.process_data(
    file_list_path=file_list_path,
    branches=["event"]
)
```

```
[pyprocess] ⭐️ Initialised Processor:
	path = 'EventNtuple/ntuple'
	use_remote = True
	location = scratch
	schema = root
	verbosity=2
[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/TestFileLists/remote_file_list.txt
[pyprocess] ✅ Successfully loaded file list
	Path: None
	Count: 10 files
[pyprocess] ⭐️ Running preprocess test
[pyread] ⭐️ Opening remote file: nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00050440.root
[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CosmicCRYSignalAllOffSpillTriggered-LH/MDC2020as_best_v1_3_v06_03_00/root/08/90/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00050440.root
[pyread] ⚠️ Exception while opening root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CosmicCRYSignalAllOffSpillTriggered-LH/MDC2020as_best_v1_3_v06_03_00/root/08/90/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00050440.root: File did not open properly: [FATAL] TLS error: Unable to validate 131.225.69.80; hostname not in SAN extension.
[pyread] ⭐️ Fallback: checking file location='scratch'
[pyread] ✅ Files found on 'disk', retrying
[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/persistent/datasets/phy-nts/nts/mu2e/CosmicCRYSignalAllOffSpillTriggered-LH/MDC2020as_best_v1_3_v06_03_00/root/08/90/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00050440.root
[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/persistent/datasets/phy-nts/nts/mu2e/CosmicCRYSignalAllOffSpillTriggered-LH/MDC2020as_best_v1_3_v06_03_00/root/08/90/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00050440.root
[pyprocess] ✅ Preprocess test passed
[pyprocess] ⭐️ Starting processing on 10 files with 10 threads

Processing: 100%|██████████████████████████████| 10[/10](https://analytics-hub.fnal.gov/10) [00:09<00:00,  1.07file[/s](https://analytics-hub.fnal.gov/s), successful=10, failed=0]

[pyprocess] ✅ Returning concatenated array containing 70255 events
[pyprocess] 👀 Array structure:
70255 * {
    event: int32
}
```


