### PR TITLE
Corrected fallback for incorrect file location (PR-36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ class Display:
 
 You can develop and test `pyutils` code by creating an editable install, as follows:
 
-```
+```bash
 mu2einit
 pyenv ana
 git clone https://github.com/Mu2e/pyutils.git
@@ -854,16 +854,28 @@ cd pyutils
 pip install -e . --user 
 ```
 
-To verify that this worked, run
+To verify that Python can import the and use your local install:
 
-```python
+```bash
 python -c "import pyutils;print(pyutils.__file__)"
 ```
 
 which should return
 
+```bash
+/path/to/dev/area/pyutils/pyutils/__init__.py 
 ```
-/path/to/dev/area/pyutils/pyutils/__init__.py
+
+To confirm that the package is registered:
+
+```bash
+pip list | grep pyutils
+```
+
+which should return
+
+```
+pyutils <version> /path/to/dev/area/pyutils # pip command
 ```
 
 Your changes will be automatically be applied to the `pyutils` installed in your environment, with no need to rerun the `pip` command, and you can import modules and classes using the same syntax as normal.

--- a/pyutils/pyimport.py
+++ b/pyutils/pyimport.py
@@ -40,7 +40,7 @@ class Importer:
             use_remote=self.use_remote,
             location=self.location,
             schema=self.schema,
-            verbosity=self.verbosity    
+            verbosity=self.verbosity
         )
         
     def import_branches(self):

--- a/pyutils/pyprocess.py
+++ b/pyutils/pyprocess.py
@@ -138,11 +138,11 @@ class Processor:
         sample_file_name = file_list[0]
 
         # Start a reader 
-        reader = Reader(use_remote=True, location=self.location, schema=self.schema, verbosity=self.verbosity)
+        reader = Reader(use_remote=self.use_remote, location=self.location, schema=self.schema, verbosity=self.verbosity)
 
         # Read the file
         try:
-            sample_file = reader._read_remote_file(sample_file_name)
+            sample_file = reader.read_file(sample_file_name)
             return True
         except Exception as e:
             self.logger.log(f"Exception during preprocessing {e}", "error")
@@ -263,7 +263,7 @@ class Processor:
         file_sources = sum(x is not None for x in [file_name, defname, file_list_path])
         if file_sources != 1: 
             self.logger.log(f"Please provide exactly one of 'file_name', 'file_list_path', or defname'", "error")
-            return None           
+            return None
 
         # Validate custom_process_func if provided
         if custom_process_func is not None:
@@ -276,7 +276,7 @@ class Processor:
             sig = inspect.signature(custom_process_func)
             if len(sig.parameters) != 1:
                 self.logger.log(f"custom_process_func must take exactly one argument (file_name)", "error")
-                return None        
+                return None
 
         # Verbosity for worker threads is the same as Processor 
         worker_verbosity = self.verbosity 
@@ -333,6 +333,7 @@ class Processor:
                     results.type.show()
             else:
                 self.logger.log(f"Concatenated array is None (failed to import branches)", "error")
+                return None
         else: 
             self.logger.log(f"Returning {len(results)} results", "info")
 

--- a/pyutils/pyutils_tests/pytest.py
+++ b/pyutils/pyutils_tests/pytest.py
@@ -201,6 +201,16 @@ class Tester:
             branches=["event"]
         )
 
+    def _local_process_file_wrong_loc(self):
+        processor = Processor(
+            use_remote=False,
+            verbosity=self.verbosity,
+            location="scratch" # INCORRECT
+        )
+        return processor.process_data(
+            file_name=self.local_file_path,
+            branches=["event"]
+        )
 
     def _local_process_wb_file(self): # WB tree structure
         processor = Processor(
@@ -229,6 +239,27 @@ class Tester:
             branches=["event"]
         )
 
+    def _remote_process_file(self):
+        processor = Processor(
+            use_remote=True,
+            verbosity=self.verbosity
+        )
+        return processor.process_data(
+            file_name=self.remote_file_name,
+            branches=["event"]
+        )
+
+    def _remote_process_file_wrong_loc(self):
+        processor = Processor(
+            use_remote=True,
+            verbosity=self.verbosity,
+            location="scratch" # INCORRECT
+        )
+        return processor.process_data(
+            file_name=self.remote_file_name,
+            branches=["event"]
+        )
+        
     def _local_get_file_list(self):
         processor = Processor(verbosity=self.verbosity)
         return processor.get_file_list(file_list_path=self.local_file_list)
@@ -306,6 +337,7 @@ class Tester:
         """Test pyprocess module"""
         if local_process_file:
             self._safe_test("pyprocess:Processor:process_data (local, single file, single branch)", self._local_process_file)
+            self._safe_test("pyprocess:Processor:process_data (local, single file, single branch, wrong file location)", self._local_process_file_wrong_loc)
 
         if local_process_wb_file:
             self._safe_test("pyprocess:Processor:process_data (local, single WB file, single branch)", self._local_process_wb_file)            
@@ -315,6 +347,7 @@ class Tester:
             
         if remote_process_file:
             self._safe_test("pyprocess:Processor:process_data (remote, single file, single branch)", self._remote_process_file)
+            self._safe_test("pyprocess:Processor:process_data (remote, single file, single branch, wrong file location)", self._remote_process_file_wrong_loc)
 
         if get_file_list:
             self._safe_test("pyprocess:Processor:get_file_list (local file list path)", self._local_get_file_list)

--- a/pyutils/pyutils_tests/run_tests.ipynb
+++ b/pyutils/pyutils_tests/run_tests.ipynb
@@ -11,6 +11,24 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "4080feeb-8f2c-4cc7-ba9a-0cd6f6a71849",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/sgrant/pyutils-dev/pyutils/pyutils/__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pyutils; print(pyutils.__file__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "9ef64825-e1ac-4157-b67f-744d1566f38a",
    "metadata": {},
    "outputs": [
@@ -45,6 +63,8 @@
       "[pytest] ✅ PASSED: pyread:Reader:read_file (local)\n",
       "[pytest] 🧪 Running test: pyread:Reader::read_file (remote)\n",
       "[pytest] 🧪 Remote read\n",
+      "[pyutils] ⭐️ Setting up...\n",
+      "[pyutils] ✅ Ready\n",
       "[pyread] ⭐️ Opening remote file: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
       "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
       "[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
@@ -117,8 +137,21 @@
       "1471 * {\n",
       "    event: int32\n",
       "}\n",
-      "[pyprocess] ✅ Returning result from process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, single branch)\n",
+      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single file, single branch, wrong file location)\n",
+      "[pyprocess] ⭐️ Initialised Processor:\n",
+      "\tpath = 'EventNtuple/ntuple'\n",
+      "\tuse_remote = False\n",
+      "\tverbosity=2\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyimport] ✅ Imported branches\n",
+      "[pyimport] 👀 Array structure:\n",
+      "1471 * {\n",
+      "    event: int32\n",
+      "}\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, single branch, wrong file location)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single WB file, single branch)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'run'\n",
@@ -130,7 +163,7 @@
       "128776 * {\n",
       "    runNumber: int32\n",
       "}\n",
-      "[pyprocess] ✅ Returning result from process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/rec.mu2e.CRV_wideband_cosmics.CRVWB-000-012-000.000105_001.root\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/rec.mu2e.CRV_wideband_cosmics.CRVWB-000-012-000.000105_001.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single WB file, single branch)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single file, special branches)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
@@ -144,7 +177,7 @@
       "    \"crvcoincs.PEsPerLayer[4]\": var * 4 * float32,\n",
       "    \"crvcoincs.sidePEsPerLayer[8]\": var * 8 * float32\n",
       "}\n",
-      "[pyprocess] ✅ Returning result from process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, special branches)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (remote, single file, single branch)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
@@ -161,8 +194,29 @@
       "1471 * {\n",
       "    event: int32\n",
       "}\n",
-      "[pyprocess] ✅ Returning result from process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (remote, single file, single branch)\n",
+      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (remote, single file, single branch, wrong file location)\n",
+      "[pyprocess] ⭐️ Initialised Processor:\n",
+      "\tpath = 'EventNtuple/ntuple'\n",
+      "\tuse_remote = True\n",
+      "\tlocation = scratch\n",
+      "\tschema = root\n",
+      "\tverbosity=2\n",
+      "[pyread] ⭐️ Opening remote file: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ⚠️ Exception while opening root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root: File did not open properly: [FATAL] TLS error: Unable to validate 131.225.69.80; hostname not in SAN extension.\n",
+      "[pyread] ⭐️ Fallback: checking file location='scratch'\n",
+      "[pyread] ✅ Files found on 'tape', retrying\n",
+      "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyimport] ✅ Imported branches\n",
+      "[pyimport] 👀 Array structure:\n",
+      "1471 * {\n",
+      "    event: int32\n",
+      "}\n",
+      "[pyprocess] ✅ Completed process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (remote, single file, single branch, wrong file location)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (local file list path)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
@@ -206,6 +260,9 @@
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
       "\tCount: 10 files\n",
+      "[pyprocess] ⭐️ Running preprocess test\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00000035.root\n",
+      "[pyprocess] ✅ Preprocess test passed\n",
       "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
      ]
     },
@@ -213,7 +270,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:01<00:00,  5.82file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:05<00:00,  1.73file/s, successful=10, failed=0]\u001b[0m\n"
      ]
     },
     {
@@ -235,6 +292,9 @@
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
       "\tCount: 10 files\n",
+      "[pyprocess] ⭐️ Running preprocess test\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00000035.root\n",
+      "[pyprocess] ✅ Preprocess test passed\n",
       "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
      ]
     },
@@ -242,7 +302,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:01<00:00,  5.71file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:01<00:00,  5.37file/s, successful=10, failed=0]\u001b[0m\n"
      ]
     },
     {
@@ -266,6 +326,9 @@
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
       "\tCount: 10 files\n",
+      "[pyprocess] ⭐️ Running preprocess test\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CosmicCRYSignalAllOffSpillTriggered-LH.MDC2020as_best_v1_3_v06_03_00.001202_00000035.root\n",
+      "[pyprocess] ✅ Preprocess test passed\n",
       "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
      ]
     },
@@ -273,7 +336,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:00<00:00, 58.42file/s, successful=10, failed=0]\u001b[0m \n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:00<00:00, 54.93file/s, successful=10, failed=0]\u001b[0m \n"
      ]
     },
     {
@@ -323,7 +386,7 @@
       "        sindex: int32\n",
       "    }, parameters={\"__record__\": \"mu2e::TrkSegInfo\"}]\n",
       "}\n",
-      "[pyprocess] ✅ Returning result from process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
       "[pytest] 🧪 Running test: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
       "[pyprint] ⭐️ Initialised Print with verbose = False and precision = 1\n",
       "[pyprint] ⭐️ Printing 1 event(s)...\n",
@@ -399,7 +462,7 @@
       "[pyselect] ✅ Returning mask for downstream track segments (p_z > 0)\n",
       "[pytest] ✅ PASSED: pyselect:Selector:is_downstream (local, single file)\n",
       "[pytest] 🧪 Running test: pyselect:Selector:is_reflected (local, single file)\n",
-      "[pyselect] ✅ Returning mask for trksegs with sid = 0 and sindex = 0\n",
+      "[pyselect] ✅ Returning mask for trksegs with sid = 0\n",
       "[pyselect] ✅ Returning mask for upstream track segments (p_z < 0)\n",
       "[pyselect] ✅ Returning mask for downstream track segments (p_z > 0)\n",
       "[pyselect] ✅ Returning mask for reflected tracks\n",
@@ -452,8 +515,8 @@
       "                ==================================================\n",
       "                TEST SUMMARY\n",
       "                ==================================================\n",
-      "                Total tests run: 40\n",
-      "                Passed: 40\n",
+      "                Total tests run: 36\n",
+      "                Passed: 36\n",
       "                Failed: 0\n",
       "                \n",
       "                🎉 All tests passed!\n"
@@ -493,9 +556,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mu2e_env [conda env:.conda-ana_v2.1.0]",
+   "display_name": "mu2e_env [conda env:.conda-ana_v2.2.0]",
    "language": "python",
-   "name": "conda-env-.conda-ana_v2.1.0-ana_v2.1.0"
+   "name": "conda-env-.conda-ana_v2.2.0-ana_v2.2.0"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
# Corrected fallback for incorrect file location  ([PR-36](https://github.com/Mu2e/pyutils/pull/36))

The location check in `pyread.py` should only be called in `pyprocess.py` if the files are remote, which it now does. I also updated `pytest.py` so test this, see below: 

**Local file with incorrect location:**

```
[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single file, single branch, wrong file location)
[pyprocess] ⭐️ Initialised Processor:
	path = 'EventNtuple/ntuple'
	use_remote = False
	verbosity=2
[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyimport] ✅ Imported branches
[pyimport] 👀 Array structure:
1471 * {
    event: int32
}
[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/TestFiles/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, single branch, wrong file location)
```

**Remote file with incorrect location:**

```
[pytest] 🧪 Running test: pyprocess:Processor:process_data (remote, single file, single branch, wrong file location)
[pyutils] ⭐️ Setting up...
[pyutils] ✅ Ready
[pyprocess] ⭐️ Initialised Processor:
	path = 'EventNtuple/ntuple'
	use_remote = True
	location = scratch
	schema = root
	verbosity=2
[pyread] ⭐️ Opening remote file: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyread] ⚠️ Exception while opening root://fndcadoor.fnal.gov:1094/mu2e/scratch/datasets/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root: File did not open properly: [FATAL] TLS error: Unable to validate 131.225.69.80; hostname not in SAN extension.
[pyread] ⭐️ Fallback: checking file location='scratch'
[pyread] ✅ Files found on 'tape', retrying
[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pyimport] ✅ Imported branches
[pyimport] 👀 Array structure:
1471 * {
    event: int32
}
[pyprocess] ✅ Completed process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root
[pytest] ✅ PASSED: pyprocess:Processor:process_data (remote, single file, single branch, wrong file location)
```

> **Note:** I also snuck in some additional instructions for developers.

