### PR TITLE
Improved error handling, multiprocess environment setup, and pytest fixes

### DIFF
--- a/pyutils/_env_manager.py
+++ b/pyutils/_env_manager.py
@@ -5,15 +5,11 @@ import os
 import subprocess
 from .pylogger import Logger
 
-ENV_IS_SETUP = False
-
 def setup_environment():
-    """Set up the environment variables once per process"""
-    global ENV_IS_SETUP
-    
+    """Set up the environment variables once"""
     logger = Logger(print_prefix="[pyutils]")
-    
-    if not ENV_IS_SETUP:
+
+    if not os.environ.get("PYUTILS_ENV_SETUP"):
         logger.log("Setting up...", "info")
         try:
             # Step 0: unset the X509_USER_PROXY in the current process 
@@ -54,7 +50,7 @@ def setup_environment():
                     key, value = line.split('=', 1)
                     os.environ[key] = value
             
-            ENV_IS_SETUP = True
+            os.environ["PYUTILS_ENV_SETUP"] = "1"
             logger.log("Ready", "success")
             return True
             
@@ -69,5 +65,5 @@ def setup_environment():
 
 def ensure_environment():
     """Ensure environment is set up before using mdh"""
-    if not ENV_IS_SETUP:
+    if not os.environ.get("PYUTILS_ENV_SETUP"):
         setup_environment()

--- a/pyutils/pyimport.py
+++ b/pyutils/pyimport.py
@@ -49,8 +49,9 @@ class Importer:
         Returns:
             Awkward array with imported data
         """
+        file = None
         try:
-            # Open file 
+            # Open file
             file = self.reader.read_file(self.file_name) 
             # Access the tree
             components = self.tree_path.split('/')

--- a/pyutils/pyprocess.py
+++ b/pyutils/pyprocess.py
@@ -154,8 +154,8 @@ class Processor:
             return None
     
         if max_workers is None:
-            # Return a sensible default for max threads
-            max_workers = min(len(file_list), os.cpu_count()) # FIXME: sensible for threads, not processes
+            max_workers = os.cpu_count() 
+        max_workers = min(max_workers, len(file_list))
 
         ExecutorClass = ProcessPoolExecutor if use_processes else ThreadPoolExecutor
         executor_type = "processes" if use_processes else "threads"

--- a/pyutils/pyprocess.py
+++ b/pyutils/pyprocess.py
@@ -293,6 +293,7 @@ class Processor:
 
         if len(results) == 0:
             self.logger.log(f"Results list has length zero", "warning")
+            return None
 
         if custom_worker_func is None:
             # Concatenate the arrays

--- a/pyutils/pyprocess.py
+++ b/pyutils/pyprocess.py
@@ -195,20 +195,14 @@ class Processor:
                         if result is not None:
                             results.append(result)
                             completed_files += 1
-                        else: 
+                        else:
+                            self.logger.log(f"Worker returned None for {file_name}", "warning")
                             failed_files += 1
-                        
-                        # Extract just the base filename for cleaner output
-                        base_file_name = file_name.split('/')[-1]
                         
                     except Exception as e:
                         self.logger.log(f"Error processing {file_name}:\n{e}", "error")
-                        # Increment failed files on exception
                         failed_files += 1
-                        # Redraw progress bar
                         pbar.refresh()
-                        # Propagete
-                        raise e
 
                     finally:
                         # Always update the progress bar, regardless of success or failure
@@ -278,10 +272,13 @@ class Processor:
             worker_func = custom_worker_func
 
         # Handle the single file case
-        if file_name: 
-            result = worker_func(file_name) # Run the process
-            self.logger.log(f"Completed process on {file_name}", "success")
-            return result 
+        if file_name:
+            result = worker_func(file_name)
+            if result is not None:
+                self.logger.log(f"Completed process on {file_name}", "success")
+            else:
+                self.logger.log(f"Worker returned None for {file_name}", "warning")
+            return result
 
         # Prepare file list
         file_list = self.get_file_list(file_list_path=file_list_path, defname=defname)
@@ -434,38 +431,43 @@ class Skeleton:
             self.logger.log(f"Please provide exactly one of 'file_name', 'file_list_path', or defname'", "error")
             return None
             
-        # Initialise the processor
-        processor = Processor(
-            tree_path=self.tree_path,
-            use_remote=self.use_remote,
-            location=self.location,
-            schema=self.schema,
-            verbosity=self.verbosity
-        )
-        
-        # Process the data
-        results = processor.process_data(
-            file_name=self.file_name, # If it's just one file it will skip the process function
-            file_list_path=self.file_list_path,
-            defname=self.defname,
-            branches=self.branches,
-            max_workers=self.max_workers,
-            custom_worker_func=self.process_file,
-            use_processes=self.use_processes 
-        )
+        try:
+            # Initialise the processor
+            processor = Processor(
+                tree_path=self.tree_path,
+                use_remote=self.use_remote,
+                location=self.location,
+                schema=self.schema,
+                verbosity=self.verbosity
+            )
 
-        # Postprocess
-        results = self.postprocess(results)
+            # Process the data
+            results = processor.process_data(
+                file_name=self.file_name, # If it's just one file it will skip the process function
+                file_list_path=self.file_list_path,
+                defname=self.defname,
+                branches=self.branches,
+                max_workers=self.max_workers,
+                custom_worker_func=self.process_file,
+                use_processes=self.use_processes
+            )
 
-        self.logger.log(f"Analysis complete", "success")
-            
-        return results
+            # Postprocess
+            results = self.postprocess(results)
+
+            if results is not None:
+                self.logger.log(f"Analysis complete", "success")
+            else:
+                self.logger.log(f"Analysis failed", "error")
+
+            return results
+
+        except Exception as e:
+            self.logger.log(f"Analysis failed: {e}", "error")
+            raise
 
     def postprocess(self, results): 
         """Run post processing on the results list 
         Placeholder method! You can override it
         """
         return results
-
-        # Such as combination 
-        

--- a/pyutils/pyread.py
+++ b/pyutils/pyread.py
@@ -60,7 +60,7 @@ class Reader:
             self.logger.log(f"Opened {file_path}", "success")
             return file
         except Exception as e:
-            self.logger.log(f"Exception while opening {file_path}: {e}", "warning")
+            self.logger.log(f"Exception while opening {file_path}: {e}", "error")
             raise # propagate exception up
 
     def _read_remote_file(self, file_path):

--- a/tests/pytest.py
+++ b/tests/pytest.py
@@ -25,11 +25,10 @@ import gc
 
 # Cannot be nested (for multiprocessing)!
 class MyProcessor(Skeleton):
-    def __init__(self, file_list_path, use_processes, max_workers=40):
+    def __init__(self, file_list_path, use_processes):
         super().__init__()
         self.file_list_path = file_list_path
         self.use_processes = use_processes
-        self.max_workers = max_workers
     def process_file(self, file_name):
         return file_name 
             
@@ -39,7 +38,6 @@ class Tester:
     def __init__(self):  
         # Max verbosity
         self.verbosity = 2
-        self.max_workers = 40
 
         # Error tracking
         self.error_count = 0
@@ -127,16 +125,16 @@ class Tester:
 
         return importer.import_branches()
 
-    def _local_import_wb_branch(self): # Wideband (WB) tree 
-        importer = Importer(
-            file_name = self.local_wb_file_path,
-            tree_path = "run",
-            branches = ["runNumber"],
-            use_remote=False,
-            verbosity = self.verbosity
-        )
+    # def _local_import_wb_branch(self): # Wideband (WB) tree
+    #     importer = Importer(
+    #         file_name = self.local_wb_file_path,
+    #         tree_path = "run",
+    #         branches = ["runNumber"],
+    #         use_remote=False,
+    #         verbosity = self.verbosity
+    #     )
 
-        return importer.import_branches()
+    #     return importer.import_branches()
 
     def _local_import_special_branch(self): # Branches with special characters in the name
         importer = Importer(
@@ -150,7 +148,7 @@ class Tester:
     
     def _remote_import_branch(self):
         importer = Importer(
-            file_name = self.local_file_path,
+            file_name = self.remote_file_name,
             branches = ["event"],
             use_remote=True,
             location="tape",
@@ -188,7 +186,7 @@ class Tester:
         local_import_special_branch=True,
         remote_import_branch=True,
         local_import_grouped_branches=True,
-        local_import_all_branches=True 
+        local_import_all_branches=False 
     ):
         """Test pyimport:Importer module"""
         self.logger.log("Testing pyimport:Importer", "info")  
@@ -201,7 +199,7 @@ class Tester:
         if local_import_special_branch:
             self._safe_test("pyimport:Importer:import_branches (local, single file, special branches)", self._local_import_special_branch)     
             
-        if local_import_branch:
+        if remote_import_branch:
             self._safe_test("pyimport:Importer:import_branches (remote, single branch)", self._remote_import_branch)
             
         if local_import_grouped_branches:
@@ -294,18 +292,18 @@ class Tester:
         )
         return processor.process_data(
             file_list_path=self.local_file_list,
-            branches = ["event"]
+            branches=["event"]
         )
 
     def _basic_remote_multithread(self):
         processor = Processor(
-            location="disk",
+            location="tape",
             verbosity=self.verbosity,
             use_remote=True
         )
         return processor.process_data(
             file_list_path=self.remote_file_list,
-            branches = ["event"]
+            branches=["event"]
         )
 
     def _basic_bad_multithread(self):
@@ -314,17 +312,17 @@ class Tester:
         )
         return processor.process_data(
             file_list_path=self.bad_local_file_list,
-            branches = ["event"]
+            branches=["event"]
         )
-        
+
     def _basic_multiprocess(self):
         processor = Processor(
-            verbosity=self.verbosity, 
+            verbosity=self.verbosity,
             worker_verbosity=2
         )
         return processor.process_data(
             file_list_path=self.local_file_list,
-            branches = ["event"],
+            branches=["event"],
             use_processes=True
         )
 
@@ -333,14 +331,14 @@ class Tester:
             verbosity=self.verbosity,
             use_remote=True,
             worker_verbosity=2,
-            location="disk"
+            location="tape"
         )
         return processor.process_data(
             file_list_path=self.remote_file_list,
-            branches = ["event"],
+            branches=["event"],
             use_processes=True
         )
-            
+
     def _advanced_multithread(self):
         my_processor = MyProcessor(self.local_file_list, False)
         return my_processor.execute()

--- a/tests/pytest.py
+++ b/tests/pytest.py
@@ -25,10 +25,11 @@ import gc
 
 # Cannot be nested (for multiprocessing)!
 class MyProcessor(Skeleton):
-    def __init__(self, file_list_path, use_processes):
+    def __init__(self, file_list_path, use_processes, max_workers=40):
         super().__init__()
-        self.file_list_path=file_list_path 
-        self.use_processes=True
+        self.file_list_path = file_list_path
+        self.use_processes = use_processes
+        self.max_workers = max_workers
     def process_file(self, file_name):
         return file_name 
             
@@ -36,9 +37,10 @@ class Tester:
     """ Tests for pyutils """
     
     def __init__(self):  
-        # Max verbosity 
-        self.verbosity = 2 
-        
+        # Max verbosity
+        self.verbosity = 2
+        self.max_workers = 40
+
         # Error tracking
         self.error_count = 0
         self.test_count = 0
@@ -50,7 +52,7 @@ class Tester:
         self.local_file_list = "MDS_local.txt"
         self.bad_local_file_list = "MDS_local_corrupted.txt"
         self.remote_file_list = "MDS_remote.txt"
-        self.defname = "nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root"
+        self.defname = "nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.root"
         
         # Setup logger 
         self.logger = Logger(

--- a/tests/pytest.py
+++ b/tests/pytest.py
@@ -47,9 +47,9 @@ class Tester:
         # Test files
         self.local_file_path = "/exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root"
         self.remote_file_name = "nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root"
-        self.local_file_list = "tests/MDS_local.txt"
-        self.bad_local_file_list = "tests/MDS_local_corrupted.txt"
-        self.remote_file_list = "tests/MDS_remote.txt"
+        self.local_file_list = "MDS_local.txt"
+        self.bad_local_file_list = "MDS_local_corrupted.txt"
+        self.remote_file_list = "MDS_remote.txt"
         self.defname = "nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root"
         
         # Setup logger 

--- a/tests/pytest.py
+++ b/tests/pytest.py
@@ -18,6 +18,8 @@ from pyutils.pyprint import Print                  # Array visualisation
 from pyutils.pyselect import Select                # Data selection and cut management 
 from pyutils.pyvector import Vector                # Element wise vector operations
 from pyutils.pylogger import Logger                # Printout manager
+import pyutils.pylogger as _pylogger
+_pylogger.USE_EMOJIS = True
 
 import gc
 
@@ -60,6 +62,7 @@ class Tester:
     def _safe_test(self, test_name, test_function, *args, expect_return=True, **kwargs):
         """Wrapper to safely run tests and count errors"""
         self.test_count += 1
+        result = None
         try:
             self.logger.log(f"Running test: {test_name}", "test")
             result = test_function(*args, **kwargs)            
@@ -247,16 +250,6 @@ class Tester:
             branches=["event"]
         )
 
-    def _remote_process_file(self):
-        processor = Processor(
-            use_remote=True,
-            verbosity=self.verbosity
-        )
-        return processor.process_data(
-            file_name=self.remote_file_name,
-            branches=["event"]
-        )
-
     def _remote_process_file_wrong_loc(self):
         processor = Processor(
             use_remote=True,
@@ -386,7 +379,7 @@ class Tester:
         if basic_multifile:
             self._safe_test("pyprocess:Processor:process_data (basic multithread)", self._basic_multithread)
             self._safe_test("pyprocess:Processor:process_data (basic remote multithread)", self._basic_remote_multithread)
-            # self._safe_test("pyprocess:Processor:process_data (basic bad multithread)", self._basic_bad_multithread)
+            self._safe_test("pyprocess:Processor:process_data (basic bad multithread)", self._basic_bad_multithread, expect_return=False)
             self._safe_test("pyprocess:Processor:process_data (basic multiprocess)", self._basic_multiprocess)
             self._safe_test("pyprocess:Processor:process_data (basic remote multiprocess)", self._basic_remote_multiprocess)
             # self._safe_test("pyprocess:Processor:process_data (basic remote multithread)", self._basic_remote_multiprocess)

--- a/tests/run.ipynb
+++ b/tests/run.ipynb
@@ -11,6 +11,24 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "eedbdd2d-f8f9-414b-828a-82d8b2d9d2a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/sgrant/pyutils-dev/pyutils/tests\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "b6649335-a092-4cdd-83b7-a873ce89d890",
    "metadata": {},
    "outputs": [
@@ -28,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "9ef64825-e1ac-4157-b67f-744d1566f38a",
    "metadata": {},
    "outputs": [
@@ -47,7 +65,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
+   "id": "96ff6b08-3baf-4f69-9c6f-2d079d31c785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tester._safe_test(\"pyprocess:Processor:process_data (basic remote multiprocess)\", tester._basic_remote_multiprocess)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "9da01fd3-b5f8-44b6-a254-3ca862375abc",
    "metadata": {},
    "outputs": [
@@ -61,21 +89,14 @@
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, single branch)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single WB file, single branch)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'run'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/rec.mu2e.CRV_wideband_cosmics.CRVWB-000-012-000.000105_001.root\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single WB file, single branch)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single file, special branches)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, special branches)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (remote, single file, single branch)\n",
       "[pyutils] ⭐️ Setting up...\n",
@@ -86,17 +107,17 @@
       "\tlocation = tape\n",
       "\tschema = root\n",
       "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyprocess] ✅ Completed process on nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (remote, single file, single branch)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (local file list path)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_local.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
+      "\tCount: 5 files\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:get_file_list (local file list path)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (remote file list path)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
@@ -105,10 +126,10 @@
       "\tlocation = tape\n",
       "\tschema = root\n",
       "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/remote_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_remote.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
+      "\tCount: 80 files\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:get_file_list (remote file list path)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (SAM definition)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
@@ -117,37 +138,37 @@
       "\tlocation = tape\n",
       "\tschema = root\n",
       "\tverbosity=2\n",
-      "[pyprocess] 👀 Loading file list for SAM definition: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.root\n",
+      "[pyprocess] 👀 Loading file list for SAM definition: nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.root\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tSAM definition: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.root\n",
-      "\tCount: 1000 files\n",
+      "\tSAM definition: nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.root\n",
+      "\tCount: 160 files\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:get_file_list (SAM definition)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic multithread)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_local.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
+      "\tCount: 5 files\n",
+      "[pyprocess] ⭐️ Starting processing on 5 files with 5 threads\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:02<00:00,  4.08file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 5/5 [01:27<00:00, 17.46s/file, successful=5, failed=0]\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
+      "[pyprocess] ✅ Returning concatenated array containing 1790034 events\n",
       "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
+      "1790034 * {\n",
       "    event: int32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic multithread)\n",
@@ -155,59 +176,88 @@
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = True\n",
-      "\tlocation = disk\n",
+      "\tlocation = tape\n",
       "\tschema = root\n",
       "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/remote_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_remote.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
+      "\tCount: 80 files\n",
+      "[pyprocess] ⭐️ Starting processing on 80 files with 78 threads\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  2.86file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 80/80 [00:33<00:00,  2.37file/s, successful=80, failed=0]\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
+      "[pyprocess] ✅ Returning concatenated array containing 1446056 events\n",
       "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
+      "1446056 * {\n",
       "    event: int32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic remote multithread)\n",
+      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic bad multithread)\n",
+      "[pyprocess] ⭐️ Initialised Processor:\n",
+      "\tpath = 'EventNtuple/ntuple'\n",
+      "\tuse_remote = False\n",
+      "\tverbosity=2\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_local_corrupted.txt\n",
+      "[pyprocess] ✅ Successfully loaded file list\n",
+      "\tPath: None\n",
+      "\tCount: 1 files\n",
+      "[pyprocess] ⭐️ Starting processing on 1 files with 1 threads\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 1/1 [00:00<00:00, 10.36file/s, successful=0, failed=1]\u001b[0m \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[pyread] ❌ Exception while opening /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_7.root: [Errno 2] No such file or directory: '/exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_7.root'\n",
+      "[pyimport] ❌ Exception getting branches in file /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_7.root: [Errno 2] No such file or directory: '/exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_7.root'\n",
+      "[pyprocess] ❌ Error processing /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_7.root:\n",
+      "[Errno 2] No such file or directory: '/exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_7.root'\n",
+      "[pyprocess] ⚠️  Results list has length zero\n",
+      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic bad multithread)\n",
       "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic multiprocess)\n",
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_local.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
+      "\tCount: 5 files\n",
+      "[pyprocess] ⭐️ Starting processing on 5 files with 5 processes\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:02<00:00,  4.76file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 5/5 [00:02<00:00,  2.01file/s, successful=5, failed=0]\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
+      "[pyprocess] ✅ Returning concatenated array containing 1790034 events\n",
       "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
+      "1790034 * {\n",
       "    event: int32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic multiprocess)\n",
@@ -215,50 +265,30 @@
       "[pyprocess] ⭐️ Initialised Processor:\n",
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = True\n",
-      "\tlocation = disk\n",
+      "\tlocation = tape\n",
       "\tschema = root\n",
       "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/remote_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_remote.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
+      "\tCount: 80 files\n",
+      "[pyprocess] ⭐️ Starting processing on 80 files with 78 processes\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  2.69file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 80/80 [00:31<00:00,  2.54file/s, successful=80, failed=0]\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
+      "[pyprocess] ✅ Returning concatenated array containing 1446056 events\n",
       "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
+      "1446056 * {\n",
       "    event: int32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic remote multiprocess)\n",
@@ -269,25 +299,25 @@
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=1\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_local.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
+      "\tCount: 5 files\n",
+      "[pyprocess] ⭐️ Starting processing on 5 files with 5 threads\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  3.03file/s, successful=10, failed=0]\u001b[0m\n"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 5/5 [00:00<00:00,  9.33file/s, successful=5, failed=0]\u001b[0m  \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pyprocess] ⭐️ Returning 10 results\n",
+      "[pyprocess] ⭐️ Returning 5 results\n",
       "[Skeleton] ✅ Analysis complete\n",
       "[pytest] ✅ PASSED: pyprocess:Skeleton (advanced multithread)\n",
       "[pytest] 🧪 Running test: pyprocess:Skeleton (advanced multiprocess)\n",
@@ -297,25 +327,25 @@
       "\tpath = 'EventNtuple/ntuple'\n",
       "\tuse_remote = False\n",
       "\tverbosity=1\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
+      "[pyprocess] ⭐️ Loading file list from MDS_local.txt\n",
       "[pyprocess] ✅ Successfully loaded file list\n",
       "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
+      "\tCount: 5 files\n",
+      "[pyprocess] ⭐️ Starting processing on 5 files with 5 processes\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  3.24file/s, successful=10, failed=0]\u001b[0m"
+      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 5/5 [00:02<00:00,  1.68file/s, successful=5, failed=0]\u001b[0m"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pyprocess] ⭐️ Returning 10 results\n",
+      "[pyprocess] ⭐️ Returning 5 results\n",
       "[Skeleton] ✅ Analysis complete\n",
       "[pytest] ✅ PASSED: pyprocess:Skeleton (advanced multiprocess)\n",
       "[pytest] 🧪 \n",
@@ -342,7 +372,7 @@
        "True"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -353,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "c7fce055-5b91-494d-9fdb-b2d11707fed2",
    "metadata": {},
    "outputs": [
@@ -365,13 +395,13 @@
       "[pytest] 🧪 Testing pyread:Reader\n",
       "[pytest] 🧪 Running test: pyread:Reader:read_file (local)\n",
       "[pytest] 🧪 Local read\n",
-      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
       "[pytest] ✅ PASSED: pyread:Reader:read_file (local)\n",
       "[pytest] 🧪 Running test: pyread:Reader::read_file (remote)\n",
       "[pytest] 🧪 Remote read\n",
-      "[pyread] ⭐️ Opening remote file: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ⭐️ Opening remote file: nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
+      "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/ensembleMDS2cMix1BBTriggered/MDC2020-000/root/ca/41/nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
+      "[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/ensembleMDS2cMix1BBTriggered/MDC2020-000/root/ca/41/nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
       "[pytest] ✅ PASSED: pyread:Reader::read_file (remote)\n",
       "[pytest] 🧪 \n",
       "                ==================================================\n",
@@ -390,7 +420,7 @@
        "True"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -401,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "cc1a8a20-8d51-4656-9747-2e6d0abafacd",
    "metadata": {},
    "outputs": [
@@ -412,45 +442,37 @@
       "[pytest] 🧪 ************ Testing pyimport ************\n",
       "[pytest] ⭐️ Testing pyimport:Importer\n",
       "[pytest] 🧪 Running test: pyimport:Importer:import_branches (local, single branch)\n",
-      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
       "[pyimport] ✅ Imported branches\n",
       "[pyimport] 👀 Array structure:\n",
-      "1471 * {\n",
+      "343678 * {\n",
       "    event: int32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyimport:Importer:import_branches (local, single branch)\n",
-      "[pytest] 🧪 Running test: pyimport:Importer:import_branches (local, single WB file, single branch)\n",
-      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/files/rec.mu2e.CRV_wideband_cosmics.CRVWB-000-012-000.000105_001.root\n",
-      "[pyimport] ✅ Imported branches\n",
-      "[pyimport] 👀 Array structure:\n",
-      "128776 * {\n",
-      "    runNumber: int32\n",
-      "}\n",
-      "[pytest] ✅ PASSED: pyimport:Importer:import_branches (local, single WB file, single branch)\n",
       "[pytest] 🧪 Running test: pyimport:Importer:import_branches (local, single file, special branches)\n",
-      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
       "[pyimport] ✅ Imported branches\n",
       "[pyimport] 👀 Array structure:\n",
-      "1471 * {\n",
+      "343678 * {\n",
       "    \"crvcoincs.PEsPerLayer[4]\": var * 4 * float32,\n",
       "    \"crvcoincs.sidePEsPerLayer[8]\": var * 8 * float32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyimport:Importer:import_branches (local, single file, special branches)\n",
       "[pytest] 🧪 Running test: pyimport:Importer:import_branches (remote, single branch)\n",
-      "[pyread] ⭐️ Opening remote file: /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/cb/5a/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ⭐️ Opening remote file: nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
+      "[pyread] ⭐️ Created file path: root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/ensembleMDS2cMix1BBTriggered/MDC2020-000/root/ca/41/nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
+      "[pyread] ✅ Opened root://fndcadoor.fnal.gov:1094/mu2e/tape/phy-nts/nts/mu2e/ensembleMDS2cMix1BBTriggered/MDC2020-000/root/ca/41/nts.mu2e.ensembleMDS2cMix1BBTriggered.MDC2020-000.001201_00000081.root\n",
       "[pyimport] ✅ Imported branches\n",
       "[pyimport] 👀 Array structure:\n",
-      "1471 * {\n",
+      "18118 * {\n",
       "    event: int32\n",
       "}\n",
       "[pytest] ✅ PASSED: pyimport:Importer:import_branches (remote, single branch)\n",
       "[pytest] 🧪 Running test: pyimport:Importer:import_branches (local, grouped branches)\n",
-      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
+      "[pyread] ✅ Opened /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
       "[pyimport] ✅ Imported branches\n",
       "[pyimport] 👀 Array structure:\n",
-      "1471 * {\n",
+      "343678 * {\n",
       "    evt: {\n",
       "        event: int32\n",
       "    },\n",
@@ -460,17 +482,12 @@
       "    }\n",
       "}\n",
       "[pytest] ✅ PASSED: pyimport:Importer:import_branches (local, grouped branches)\n",
-      "[pytest] 🧪 Running test: pyimport:Importer:import_branches (local, all branches)\n",
-      "[pyread] ✅ Opened /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pyimport] ⭐️ Importing all branches\n",
-      "[pyimport] ✅ Imported branches\n",
-      "[pytest] ✅ PASSED: pyimport:Importer:import_branches (local, all branches)\n",
       "[pytest] 🧪 \n",
       "                ==================================================\n",
       "                TEST SUMMARY\n",
       "                ==================================================\n",
-      "                Total tests run: 21\n",
-      "                Passed: 21\n",
+      "                Total tests run: 19\n",
+      "                Passed: 19\n",
       "                Failed: 0\n",
       "                \n",
       "                🎉 All tests passed!\n"
@@ -482,7 +499,7 @@
        "True"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,311 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "ec2bc74a-4b2a-4a1c-8bcf-95e175ccc919",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pytest] 🧪 ************ Testing pyprocess ************\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single file, single branch)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, single branch)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single WB file, single branch)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'run'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/rec.mu2e.CRV_wideband_cosmics.CRVWB-000-012-000.000105_001.root\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single WB file, single branch)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (local, single file, special branches)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (local, single file, special branches)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (remote, single file, single branch)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = True\n",
-      "\tlocation = tape\n",
-      "\tschema = root\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (remote, single file, single branch)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (local file list path)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:get_file_list (local file list path)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (remote file list path)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = True\n",
-      "\tlocation = tape\n",
-      "\tschema = root\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/remote_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:get_file_list (remote file list path)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:get_file_list (SAM definition)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = True\n",
-      "\tlocation = tape\n",
-      "\tschema = root\n",
-      "\tverbosity=2\n",
-      "[pyprocess] 👀 Loading file list for SAM definition: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.root\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tSAM definition: nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.root\n",
-      "\tCount: 1000 files\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:get_file_list (SAM definition)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic multithread)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:02<00:00,  3.69file/s, successful=10, failed=0]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
-      "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
-      "    event: int32\n",
-      "}\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic multithread)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic remote multithread)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = True\n",
-      "\tlocation = disk\n",
-      "\tschema = root\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/remote_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 threads\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  2.59file/s, successful=10, failed=0]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
-      "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
-      "    event: int32\n",
-      "}\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic remote multithread)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic multiprocess)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:02<00:00,  4.71file/s, successful=10, failed=0]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
-      "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
-      "    event: int32\n",
-      "}\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic multiprocess)\n",
-      "[pytest] 🧪 Running test: pyprocess:Processor:process_data (basic remote multiprocess)\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = True\n",
-      "\tlocation = disk\n",
-      "\tschema = root\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/remote_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  2.51file/s, successful=10, failed=0]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyutils] ⭐️ Setting up...\n",
-      "[pyutils] ✅ Ready\n",
-      "[pyprocess] ✅ Returning concatenated array containing 70255 events\n",
-      "[pyprocess] 👀 Array structure:\n",
-      "70255 * {\n",
-      "    event: int32\n",
-      "}\n",
-      "[pytest] ✅ PASSED: pyprocess:Processor:process_data (basic remote multiprocess)\n",
-      "[pytest] 🧪 Running test: pyprocess:Skeleton (advanced multithread)\n",
-      "[Skeleton] ⭐️ Skeleton init\n",
-      "[Skeleton] ⭐️ Starting analysis\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=1\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  3.07file/s, successful=10, failed=0]\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pyprocess] ⭐️ Returning 10 results\n",
-      "[Skeleton] ✅ Analysis complete\n",
-      "[pytest] ✅ PASSED: pyprocess:Skeleton (advanced multithread)\n",
-      "[pytest] 🧪 Running test: pyprocess:Skeleton (advanced multiprocess)\n",
-      "[Skeleton] ⭐️ Skeleton init\n",
-      "[Skeleton] ⭐️ Starting analysis\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=1\n",
-      "[pyprocess] ⭐️ Loading file list from /exp/mu2e/data/users/sgrant/pyutils-test/filelists/local_file_list.txt\n",
-      "[pyprocess] ✅ Successfully loaded file list\n",
-      "\tPath: None\n",
-      "\tCount: 10 files\n",
-      "[pyprocess] ⭐️ Starting processing on 10 files with 10 processes\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Processing: 100%|\u001b[32m██████████████████████████████\u001b[0m| 10/10 [00:03<00:00,  3.05file/s, successful=10, failed=0]\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pyprocess] ⭐️ Returning 10 results\n",
-      "[Skeleton] ✅ Analysis complete\n",
-      "[pytest] ✅ PASSED: pyprocess:Skeleton (advanced multiprocess)\n",
-      "[pytest] 🧪 \n",
-      "                ==================================================\n",
-      "                TEST SUMMARY\n",
-      "                ==================================================\n",
-      "                Total tests run: 34\n",
-      "                Passed: 34\n",
-      "                Failed: 0\n",
-      "                \n",
-      "                🎉 All tests passed!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tester.run(test_processor=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "12cf4f0a-ff32-4a3d-870c-694767daa3d8",
    "metadata": {},
    "outputs": [
@@ -843,176 +556,8 @@
       "                ==================================================\n",
       "                TEST SUMMARY\n",
       "                ==================================================\n",
-      "                Total tests run: 44\n",
-      "                Passed: 44\n",
-      "                Failed: 0\n",
-      "                \n",
-      "                🎉 All tests passed!\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tester.run(test_select=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "8fba19ef-8fbf-4fe9-9d49-9aada4afab24",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pytest] 🧪 ************ Testing pyprint ************\n",
-      "[pyprocess] ⭐️ Initialised Processor:\n",
-      "\tpath = 'EventNtuple/ntuple'\n",
-      "\tuse_remote = False\n",
-      "\tverbosity=2\n",
-      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/sgrant/pyutils-test/files/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000699.root\n",
-      "[pytest] 🧪 Running test: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
-      "[pyprint] ⭐️ Initialised Print with verbose = False and precision = 1\n",
-      "[pyprint] ⭐️ Printing 1 event(s)...\n",
-      "\n",
-      "-------------------------------------------------------------------------------------\n",
-      "event: 1\n",
-      "crvcoincs.PEs: []\n",
-      "trk.pdg: [11, -11, 13, -13]\n",
-      "trksegs.mom.fCoordinates.fX: [[-63.1, -63.1, -54.4, -39.9, -24.1, ..., -78.9, 54.9, -76.2, -55.1, -14], ...]\n",
-      "trksegs.mom.fCoordinates.fY: [[-66.1, -66.2, -73.5, -82.1, -88, ..., 21.2, -59.7, 14, -52, -73.4], ...]\n",
-      "trksegs.mom.fCoordinates.fZ: [[-51.1, -51.1, -51.1, -51.1, -51.1, ..., 64.5, 65.1, 69.1, 70.6, 71.2], ...]\n",
-      "trksegs.pos.fCoordinates.fX: [[59, 58.9, 41.5, 20.9, 6.91, 1.05, ..., 283, 57.1, 291, 74.7, 0.164], ...]\n",
-      "trksegs.pos.fCoordinates.fY: [[46.4, 46.3, 25.6, -8.39, -45.5, -75, ..., 99.9, -295, 120, 49.4, -89.2], ...]\n",
-      "trksegs.pos.fCoordinates.fZ: [[-4e+03, -4e+03, -4.01e+03, -4.03e+03, ..., -1.63e+03, 10.1, 1.64e+03], ...]\n",
-      "trksegs.time: [[500, 500, 500, 500, 500, 500, 505, ..., 550, 560, 562, 567, 575, 583], ...]\n",
-      "trksegs.dmom: [[0, 0, -0.0722, -0.0722, -0.0721, 0, ..., -0.119, -0.116, 0, 0, 0], ..., [...]]\n",
-      "trksegs.momerr: [[nan, nan, nan, nan, nan, ..., 0.0914, 0.0902, 0.089, 0.0865, 0.0852], ...]\n",
-      "trksegs.inbounds: [[True, True, True, True, True, True, ..., True, True, True, True, True], ...]\n",
-      "trksegs.gap: [[False, True, False, False, False, ..., False, False, False, False], ...]\n",
-      "trksegs.early: [[True, False, False, False, False, ..., False, False, False, False], ...]\n",
-      "trksegs.late: [[False, False, False, False, False, ..., False, False, False, True], ...]\n",
-      "trksegs.sid: [[103, 103, 104, 104, 104, 103, 104, 104, ..., 104, 104, 90, 90, 0, 1, 2], ...]\n",
-      "trksegs.sindex: [[0, 0, 31, 30, 29, 0, 2, 1, 10, 11, 12, 0, 0, 0, 0, 0], ..., [0, 0, ..., 0, 0]]\n",
-      "-------------------------------------------------------------------------------------\n",
-      "\n",
-      "[pytest] ✅ PASSED: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
-      "[pytest] 🧪 Running test: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
-      "[pyprint] ⭐️ Initialised Print with verbose = True and precision = 1\n",
-      "[pyprint] ⭐️ Printing 1 event(s)...\n",
-      "\n",
-      "-------------------------------------------------------------------------------------\n",
-      "event: 1\n",
-      "crvcoincs.PEs: []\n",
-      "trk.pdg: [11, -11, 13, -13]\n",
-      "trksegs.mom.fCoordinates.fX: [[-63.1, -63.1, -54.4, -39.9, -24.1, -11.4, -55.1, -32.6, -68.4, -51.6, -32.2, -78.9, 54.9, -76.2, -55.1, -14.0], [55.1, 75.4, -54.0, 77.4, 18.9, 31.8, 50.7, 67.1, 29.4, 48.2, 64.5, -58.6, 78.1, -59.6], [-66.4, -51.6, -33.1, -13.0, -10.7, -63.2, -24.6, -79.7, 55.5, -76.7, -55.0, -13.9], [55.7, 75.3, -53.9, 77.1, 19.1, 21.7, 41.4, 59.1, 20.9, 39.7, 56.5, -58.2, 77.5, -72.2]]\n",
-      "trksegs.mom.fCoordinates.fY: [[-66.1, -66.2, -73.5, -82.1, -88.0, -90.5, -79.2, -90.7, -65.2, -79.1, -88.7, 21.2, -59.7, 14.0, -52.0, -73.4], [51.9, -13.9, 59.2, -22.1, 90.9, 87.2, 77.7, 64.0, 87.5, 78.6, 65.9, 54.7, -15.5, 48.0], [-68.3, -80.0, -89.1, -94.0, -94.1, -71.7, -92.2, 20.7, -59.9, 13.1, -52.0, -72.8], [52.3, -14.4, 59.4, -22.9, 90.4, 89.8, 82.4, 70.6, 88.6, 81.8, 71.0, 54.2, -14.6, 25.3]]\n",
-      "trksegs.mom.fCoordinates.fZ: [[-51.1, -51.1, -51.1, -51.1, -51.1, -51.0, -40.2, -40.2, 44.2, 44.1, 44.1, 64.5, 65.1, 69.1, 70.6, 71.2], [-70.6, -69.1, -64.9, -64.3, -44.4, -44.4, -44.4, -44.4, 45.0, 44.9, 44.8, 63.8, 64.3, 67.8], [-46.1, -46.2, -46.1, -46.1, -46.0, 44.2, 44.0, 64.9, 65.3, 69.4, 70.5, 71.3], [-70.4, -68.9, -64.8, -64.0, -44.2, -44.2, -44.1, -44.1, 45.6, 45.5, 45.4, 62.6, 62.9, 65.3]]\n",
-      "trksegs.pos.fCoordinates.fX: [[59.0, 58.9, 41.5, 20.9, 6.9, 1.0, 35.5, 11.2, 55.1, 24.8, 3.6, 282.9, 57.1, 290.5, 74.7, 0.2], [75.3, 290.1, 58.1, 285.1, -1.8, 6.3, 27.1, 56.7, 9.7, 29.0, 57.1, 67.2, 282.1, 80.9], [57.5, 31.2, 10.8, -0.4, -1.0, 41.8, -3.2, 281.7, 56.9, 287.7, 74.6, 4.6], [70.6, 290.3, 56.1, 285.7, -2.5, -1.2, 14.8, 40.2, 4.7, 19.6, 43.2, 67.7, 281.3, 155.3]]\n",
-      "trksegs.pos.fCoordinates.fY: [[46.4, 46.3, 25.6, -8.4, -45.5, -75.0, 18.4, -28.8, 34.9, -1.6, -44.0, 99.9, -294.5, 120.4, 49.4, -89.2], [49.4, 115.2, -294.3, 93.4, -75.0, -46.5, -5.0, 30.6, -41.9, -0.6, 35.3, -292.4, 102.0, -337.1], [48.1, 15.1, -25.8, -70.1, -75.0, 24.1, -60.0, 103.1, -294.6, 123.3, 49.2, -90.0], [52.4, 114.3, -294.7, 91.6, -75.0, -69.2, -25.7, 13.1, -59.1, -17.4, 20.1, -292.3, 104.2, -374.8]]\n",
-      "trksegs.pos.fCoordinates.fZ: [[-3995.9, -3996.0, -4011.1, -4033.3, -4055.6, -4072.4, -4655.6, -4677.8, -4477.8, -4455.6, -4433.3, -2933.6, -2448.7, -1631.1, 10.1, 1639.1], [10.1, -1631.1, -2448.7, -2934.5, -4419.2, -4433.3, -4455.6, -4477.8, -4433.3, -4411.1, -4388.9, -2885.1, -2400.6, -1631.1], [-4324.0, -4344.4, -4366.7, -4388.9, -4391.3, -4477.8, -4433.3, -2939.1, -2453.4, -1631.1, 10.1, 1639.1], [10.1, -1631.1, -2445.5, -2930.7, -4408.3, -4411.1, -4433.3, -4455.6, -4366.7, -4344.4, -4322.2, -2789.5, -2310.3, -1631.1]]\n",
-      "trksegs.time: [[499.9, 499.9, 500.0, 500.2, 500.3, 500.4, 504.9, 505.1, 549.9, 550.1, 550.3, 559.8, 562.4, 566.6, 574.7, 582.6], [572.9, 581.0, 585.2, 587.8, 597.1, 597.2, 597.4, 597.6, 649.5, 649.7, 649.9, 659.2, 661.8, 665.8], [474.3, 474.5, 474.8, 475.0, 475.0, 539.6, 540.1, 553.7, 557.4, 563.4, 575.0, 586.3], [572.4, 584.1, 590.0, 593.7, 607.1, 607.1, 607.3, 607.6, 682.1, 682.4, 682.6, 696.3, 700.1, 705.2]]\n",
-      "trksegs.dmom: [[0.0, 0.0, -0.1, -0.1, -0.1, 0.0, -0.1, -0.1, -0.1, -0.1, -0.1, -0.1, -0.1, 0.0, 0.0, 0.0], [0.0, 0.0, -0.1, -0.1, 0.0, -0.1, -0.1, -0.1, -0.1, -0.1, -0.1, -0.1, -0.1, 0.0], [0.0, -0.2, -0.2, -0.2, 0.0, -0.2, -0.2, -0.3, -0.3, 0.0, 0.0, 0.0], [0.0, 0.0, -0.3, -0.3, 0.0, -0.2, -0.2, -0.2, -0.2, -0.2, -0.2, -0.3, -0.3, 0.0]]\n",
-      "trksegs.momerr: [[nan, nan, nan, nan, nan, nan, nan, nan, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, nan, nan, nan, nan, nan, nan], [0.2, 0.2, 0.2, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, nan, nan, nan, nan, nan, nan]]\n",
-      "trksegs.inbounds: [[True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True], [True, True, True, True, True, True, True, True, True, True, True, True, True, True], [True, True, True, True, True, True, True, True, True, True, True, True], [True, True, True, True, True, True, True, True, True, True, True, True, True, True]]\n",
-      "trksegs.gap: [[False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False], [False, False, False, False, False, False, False, False, False, False, False, False, False, False], [False, False, False, False, False, False, False, False, False, False, False, False], [False, False, False, False, False, False, False, False, False, False, False, False, False, False]]\n",
-      "trksegs.early: [[True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False], [True, False, False, False, False, False, False, False, False, False, False, False, False, False], [True, False, False, False, False, False, False, False, False, False, False, False], [True, False, False, False, False, False, False, False, False, False, False, False, False, False]]\n",
-      "trksegs.late: [[False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True], [False, False, False, False, False, False, False, False, False, False, False, False, False, True], [False, False, False, False, False, False, False, False, False, False, False, True], [False, False, False, False, False, False, False, False, False, False, False, False, False, True]]\n",
-      "trksegs.sid: [[103, 103, 104, 104, 104, 103, 104, 104, 104, 104, 104, 90, 90, 0, 1, 2], [1, 0, 90, 90, 103, 104, 104, 104, 104, 104, 104, 90, 90, 0], [103, 104, 104, 104, 103, 104, 104, 90, 90, 0, 1, 2], [1, 0, 90, 90, 103, 104, 104, 104, 104, 104, 104, 90, 90, 0]]\n",
-      "trksegs.sindex: [[0, 0, 31, 30, 29, 0, 2, 1, 10, 11, 12, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 12, 11, 10, 12, 13, 14, 0, 0, 0], [0, 16, 15, 14, 0, 10, 12, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 13, 12, 11, 15, 16, 17, 0, 0, 0]]\n",
-      "-------------------------------------------------------------------------------------\n",
-      "\n",
-      "[pytest] ✅ PASSED: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
-      "[pytest] 🧪 \n",
-      "                ==================================================\n",
-      "                TEST SUMMARY\n",
-      "                ==================================================\n",
-      "                Total tests run: 46\n",
-      "                Passed: 46\n",
-      "                Failed: 0\n",
-      "                \n",
-      "                🎉 All tests passed!\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tester.run(test_print=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "58348e11-2ab9-457e-9ad3-60cdd4f35d0f",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[pytest] 🧪 ************ Testing pyvector ************\n",
-      "[pyvector] ⭐️ Initialised Vector with verbosity = 2\n",
-      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
-      "[pyvector] ✅ Created 3D 'mom' vector\n",
-      "1471 * var * var * Vector3D[\n",
-      "    x: float32,\n",
-      "    y: float32,\n",
-      "    z: float32\n",
-      "]\n",
-      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
-      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
-      "[pyvector] ✅ Created 3D 'pos' vector\n",
-      "1471 * var * var * Vector3D[\n",
-      "    x: float32,\n",
-      "    y: float32,\n",
-      "    z: float32\n",
-      "]\n",
-      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
-      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
-      "[pyvector] ✅ Created 3D 'mom' vector\n",
-      "1471 * var * var * Vector3D[\n",
-      "    x: float32,\n",
-      "    y: float32,\n",
-      "    z: float32\n",
-      "]\n",
-      "[pyvector] ✅ Got 'mom' magnitude\n",
-      "1471 * var * var * float32\n",
-      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
-      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
-      "[pyvector] ✅ Created 3D 'pos' vector\n",
-      "1471 * var * var * Vector3D[\n",
-      "    x: float32,\n",
-      "    y: float32,\n",
-      "    z: float32\n",
-      "]\n",
-      "[pyvector] ✅ Got 'pos' magnitude\n",
-      "1471 * var * var * float32\n",
-      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
-      "[pytest] 🧪 \n",
-      "                ==================================================\n",
-      "                TEST SUMMARY\n",
-      "                ==================================================\n",
-      "                Total tests run: 50\n",
-      "                Passed: 50\n",
+      "                Total tests run: 42\n",
+      "                Passed: 42\n",
       "                Failed: 0\n",
       "                \n",
       "                🎉 All tests passed!\n"
@@ -1030,27 +575,79 @@
     }
    ],
    "source": [
-    "tester.run(test_vector=True)"
+    "tester.run(test_select=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a7c29294-b3e0-4da6-8bb2-f6aa99f8db14",
+   "id": "8fba19ef-8fbf-4fe9-9d49-9aada4afab24",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[pytest] 🧪 ************ Testing pyplot ************\n",
-      "[pyplot] ⭐️ Initialised Plot with mu2e.mplstyle and verbosity = 1\n",
+      "[pytest] 🧪 ************ Testing pyprint ************\n",
+      "[pyprocess] ⭐️ Initialised Processor:\n",
+      "\tpath = 'EventNtuple/ntuple'\n",
+      "\tuse_remote = False\n",
+      "\tverbosity=2\n",
+      "[pyprocess] ✅ Completed process on /exp/mu2e/data/users/mu2epro/ensembles/MDS3/MDS3a/merged_files_1/nts.mu2e.ensembleMDS3aMix1BB_CeMLeadingLog_1e-13_13629088.1_5.root\n",
+      "[pytest] 🧪 Running test: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
+      "[pyprint] ⭐️ Initialised Print with verbose = False and precision = 1\n",
+      "[pyprint] ⭐️ Printing 1 event(s)...\n",
+      "\n",
+      "[pyprint] ⭐️ -------------------------------------------------------------------------------------\n",
+      "[pyprint] ⭐️ event: 1\n",
+      "[pyprint] ⭐️ crvcoincs.PEs: [518]\n",
+      "[pyprint] ⭐️ trk.pdg: [-11, 11, -13, 13]\n",
+      "[pyprint] ⭐️ trksegs.mom.fCoordinates.fX: [[-112, 48.6, 107, -115, 57.9], ..., [111, 106, -48.9, ..., 117, -115, -34.7]]\n",
+      "[pyprint] ⭐️ trksegs.mom.fCoordinates.fY: [[-71.6, 108, -55.3, 21.7, 148], ..., [71.3, 69.4, -109, ..., -46.2, -154]]\n",
+      "[pyprint] ⭐️ trksegs.mom.fCoordinates.fZ: [[92.1, 108, 107, 110, 29.8], ..., [-92, 98.7, -109, ..., -110, 101, -29.4]]\n",
+      "[pyprint] ⭐️ trksegs.pos.fCoordinates.fX: [[-40.7, -604, -61.1, -329, -478], ..., [-39, -33.7, -604, ..., -412, -487]]\n",
+      "[pyprint] ⭐️ trksegs.pos.fCoordinates.fY: [[-297, 197, 377, -350, 129], [...], ..., [-297, -298, 197, 373, -358, 388, 83]]\n",
+      "[pyprint] ⭐️ trksegs.pos.fCoordinates.fZ: [[-2.94e+03, 10.1, -1.63e+03, 1.64e+03, -5.26e+03], ..., [-2.94e+03, ...]]\n",
+      "[pyprint] ⭐️ trksegs.time: [[1.08e+03, 1.1e+03, 1.09e+03, 1.1e+03, 1.06e+03], [...], ..., [1.11e+03, ...]]\n",
+      "[pyprint] ⭐️ trksegs.dmom: [[-0.199, 0, 0, 0, 0], [-0.0949, ..., 0], ..., [-0.233, -0.246, 0, 0, 0, 0, 0]]\n",
+      "[pyprint] ⭐️ trksegs.momerr: [[0.51, 0.505, 0.51, 0.495, 0.51], ..., [0.612, 0.612, ..., 0.613, 0.612]]\n",
+      "[pyprint] ⭐️ trksegs.inbounds: [[True, True, True, True, True], ..., [True, True, True, ..., True, True, True]]\n",
+      "[pyprint] ⭐️ trksegs.gap: [[False, False, False, False, False], ..., [False, False, ..., False, False]]\n",
+      "[pyprint] ⭐️ trksegs.sid: [[90, 1, 0, 2, 95], [90, 90, 1, ..., 2, 0, 95], ..., [90, 90, 1, 0, 2, 0, 95]]\n",
+      "[pyprint] ⭐️ trksegs.sindex: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, ...], [0, 0, 0, 0, 0, 0, 0]]\n",
+      "[pyprint] ⭐️ -------------------------------------------------------------------------------------\n",
+      "[pyprint] ⭐️ \n",
+      "[pytest] ✅ PASSED: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
+      "[pytest] 🧪 Running test: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
+      "[pyprint] ⭐️ Initialised Print with verbose = True and precision = 1\n",
+      "[pyprint] ⭐️ Printing 1 event(s)...\n",
+      "\n",
+      "[pyprint] ⭐️ -------------------------------------------------------------------------------------\n",
+      "[pyprint] ⭐️ event: 1\n",
+      "[pyprint] ⭐️ crvcoincs.PEs: [517.7]\n",
+      "[pyprint] ⭐️ trk.pdg: [-11, 11, -13, 13]\n",
+      "[pyprint] ⭐️ trksegs.mom.fCoordinates.fX: [[-111.7, 48.6, 106.9, -115.1, 57.9], [111.3, 106.1, -49.0, -106.8, 116.6, -125.0, -45.5], [-112.0, 48.8, 105.0, -115.8, 56.4], [111.1, 106.2, -48.9, -106.2, 116.6, -115.5, -34.7]]\n",
+      "[pyprint] ⭐️ trksegs.mom.fCoordinates.fY: [[-71.6, 108.4, -55.3, 21.7, 147.8], [71.4, 69.5, -108.7, 54.9, -19.1, -1.7, -151.5], [-71.4, 108.8, -58.4, 20.6, 148.8], [71.3, 69.4, -108.7, 55.8, -21.4, -46.2, -154.1]]\n",
+      "[pyprint] ⭐️ trksegs.mom.fCoordinates.fZ: [[92.1, 108.4, 107.4, 109.8, 29.8], [-91.9, 99.0, -108.9, -107.2, -110.5, 101.1, -29.5], [92.8, 108.8, 108.3, 110.1, 30.4], [-92.0, 98.7, -108.8, -107.4, -109.9, 101.4, -29.4]]\n",
+      "[pyprint] ⭐️ trksegs.pos.fCoordinates.fX: [[-40.7, -603.6, -61.1, -328.8, -477.5], [-39.8, -36.6, -603.5, -61.2, -317.6, -270.6, -483.4], [-40.0, -603.6, -48.7, -325.1, -476.2], [-39.0, -33.7, -603.6, -57.3, -326.0, -411.8, -486.7]]\n",
+      "[pyprint] ⭐️ trksegs.pos.fCoordinates.fY: [[-297.2, 196.9, 376.8, -349.6, 129.5], [-297.4, -297.8, 196.8, 375.6, -357.2, 425.8, 104.5], [-297.3, 196.8, 370.1, -353.6, 126.2], [-297.5, -298.1, 196.8, 372.6, -358.0, 387.7, 83.0]]\n",
+      "[pyprint] ⭐️ trksegs.pos.fCoordinates.fZ: [[-2941.6, 10.1, -1631.1, 1639.1, -5259.8], [-2939.5, -2444.9, 10.1, -1631.1, 1639.1, -1631.1, -5261.9], [-2957.8, 10.1, -1631.1, 1639.1, -5292.3], [-2943.3, -2556.3, 10.1, -1631.1, 1639.1, -1631.1, -5275.2]]\n",
+      "[pyprint] ⭐️ trksegs.time: [[1081.7, 1096.8, 1088.6, 1104.8, 1062.1], [1109.5, 1167.4, 1094.4, 1102.6, 1086.4, 1171.8, 1129.2], [1078.8, 1096.9, 1087.1, 1106.4, 1055.3], [1113.8, 1182.7, 1095.7, 1105.5, 1086.1, 1188.6, 1137.3]]\n",
+      "[pyprint] ⭐️ trksegs.dmom: [[-0.2, 0.0, 0.0, 0.0, 0.0], [-0.1, -0.1, 0.0, 0.0, 0.0, 0.0, 0.0], [-0.2, 0.0, 0.0, 0.0, 0.0], [-0.2, -0.2, 0.0, 0.0, 0.0, 0.0, 0.0]]\n",
+      "[pyprint] ⭐️ trksegs.momerr: [[0.5, 0.5, 0.5, 0.5, 0.5], [0.5, nan, 0.5, 0.5, 0.5, nan, 0.5], [0.6, 0.6, 0.6, 0.6, 0.6], [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]]\n",
+      "[pyprint] ⭐️ trksegs.inbounds: [[True, True, True, True, True], [True, True, True, True, True, True, True], [True, True, True, True, True], [True, True, True, True, True, True, True]]\n",
+      "[pyprint] ⭐️ trksegs.gap: [[False, False, False, False, False], [False, False, False, False, False, False, False], [False, False, False, False, False], [False, False, False, False, False, False, False]]\n",
+      "[pyprint] ⭐️ trksegs.sid: [[90, 1, 0, 2, 95], [90, 90, 1, 0, 2, 0, 95], [90, 1, 0, 2, 95], [90, 90, 1, 0, 2, 0, 95]]\n",
+      "[pyprint] ⭐️ trksegs.sindex: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0]]\n",
+      "[pyprint] ⭐️ -------------------------------------------------------------------------------------\n",
+      "[pyprint] ⭐️ \n",
+      "[pytest] ✅ PASSED: pyprint:Print:print_n_events (local, single file, verbose=False)\n",
       "[pytest] 🧪 \n",
       "                ==================================================\n",
       "                TEST SUMMARY\n",
       "                ==================================================\n",
-      "                Total tests run: 50\n",
-      "                Passed: 50\n",
+      "                Total tests run: 44\n",
+      "                Passed: 44\n",
       "                Failed: 0\n",
       "                \n",
       "                🎉 All tests passed!\n"
@@ -1068,39 +665,127 @@
     }
    ],
    "source": [
-    "tester.run(test_plot=True)"
+    "tester.run(test_print=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ef6051d6-9a5c-4f4a-815d-07157ca0f6cc",
+   "execution_count": 11,
+   "id": "58348e11-2ab9-457e-9ad3-60cdd4f35d0f",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[pytest] 🧪 ************ Testing pyvector ************\n",
+      "[pyvector] ⭐️ Initialised Vector with verbosity = 2\n",
+      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
+      "[pyvector] ✅ Created 3D 'mom' vector\n",
+      "343678 * var * var * Vector3D[\n",
+      "    x: float32,\n",
+      "    y: float32,\n",
+      "    z: float32\n",
+      "]\n",
+      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
+      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
+      "[pyvector] ✅ Created 3D 'pos' vector\n",
+      "343678 * var * var * Vector3D[\n",
+      "    x: float32,\n",
+      "    y: float32,\n",
+      "    z: float32\n",
+      "]\n",
+      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
+      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
+      "[pyvector] ✅ Created 3D 'mom' vector\n",
+      "343678 * var * var * Vector3D[\n",
+      "    x: float32,\n",
+      "    y: float32,\n",
+      "    z: float32\n",
+      "]\n",
+      "[pyvector] ✅ Got 'mom' magnitude\n",
+      "343678 * var * var * float32\n",
+      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, mom)\n",
+      "[pytest] 🧪 Running test: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
+      "[pyvector] ✅ Created 3D 'pos' vector\n",
+      "343678 * var * var * Vector3D[\n",
+      "    x: float32,\n",
+      "    y: float32,\n",
+      "    z: float32\n",
+      "]\n",
+      "[pyvector] ✅ Got 'pos' magnitude\n",
+      "343678 * var * var * float32\n",
+      "[pytest] ✅ PASSED: pyvector:Vector:get_vector (local, single file, trksegs, pos)\n",
+      "[pytest] 🧪 \n",
+      "                ==================================================\n",
+      "                TEST SUMMARY\n",
+      "                ==================================================\n",
+      "                Total tests run: 48\n",
+      "                Passed: 48\n",
+      "                Failed: 0\n",
+      "                \n",
+      "                🎉 All tests passed!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tester.run(test_vector=True)"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b1aeb918-fa09-49f4-81e3-667840977e2d",
+   "execution_count": 12,
+   "id": "a7c29294-b3e0-4da6-8bb2-f6aa99f8db14",
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b692b9ca-f14e-4793-a1d7-bd81463a6693",
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[pytest] 🧪 ************ Testing pyplot ************\n",
+      "[pyplot] ⭐️ Initialised Plot with mu2e.mplstyle and verbosity = 1\n",
+      "[pytest] 🧪 \n",
+      "                ==================================================\n",
+      "                TEST SUMMARY\n",
+      "                ==================================================\n",
+      "                Total tests run: 48\n",
+      "                Passed: 48\n",
+      "                Failed: 0\n",
+      "                \n",
+      "                🎉 All tests passed!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tester.run(test_plot=True)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mu2e_env [conda env:.conda-ana_v2.2.0]",
+   "display_name": "mu2e_env [conda env:.conda-dev]",
    "language": "python",
-   "name": "conda-env-.conda-ana_v2.2.0-ana_v2.2.0"
+   "name": "conda-env-.conda-dev-ana_v2.5.0"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1112,7 +797,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Improved error handling, multiprocess environment setup, and `pytest` fixes

## Error handling (`pyprocess.py`)

- Skip failed files in parallel processing instead of crashing the batch
- Add warnings for None worker returns
- Fix `Skeleton.execute()` falsely logging success when results are None
- Cap `max_workers` to file list length

## Environment setup (`_env_manager.py`)

- Replace Python-global `ENV_IS_SETUP` with `os.environ["PYUTILS_ENV_SETUP"]`: spawned worker processes now inherit setup state from the parent and skip redundant re-initialisation

## Bug fixes (`pyread.py`, `pyimport.py)`

- Correct log level for file open failures
- Fix `UnboundLocalError` in finally block when file open fails before `file` variable is assigned
- Various minor fixes to test module (`pytest.py`)